### PR TITLE
`.gitignore` and XPC Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,74 @@
+# Created by https://www.toptal.com/developers/gitignore/api/go,macos,git
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,macos,git
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/go,macos,git

--- a/script.js
+++ b/script.js
@@ -40,6 +40,8 @@ const xpc_array_get_value = getFunc("xpc_array_get_value", "pointer", ["pointer"
 const xpc_data_get_length = getFunc("xpc_data_get_length", "int", ["pointer"]);
 const xpc_data_get_bytes = getFunc("xpc_data_get_bytes", "int", ["pointer", "pointer", "int", "int"]);
 
+const xpc_date_get_value = getFunc("xpc_date_get_value", "int64", ["pointer"]);
+
 const xpc_connection_get_pid = getFunc("xpc_connection_get_pid", "int", ["pointer"]);
 
 // helper function that will create new NativeFunction
@@ -68,6 +70,22 @@ function rcstr(cstr) {
 function getXPCString(val) {
     var content = xpc_string_get_string_ptr(val);
     return rcstr(content)
+}
+
+// get human-readable date from Unix timestamp
+function getXPCDate(val) {
+    var nanoseconds = xpc_date_get_value(val);
+
+    // Convert nanoseconds to milliseconds
+    const timestampInMilliseconds = nanoseconds / 1000000;
+
+    // Create a JavaScript Date object in UTC
+    const date = new Date(timestampInMilliseconds);
+
+    return {
+        iso: date.toISOString(),
+        nanoseconds: nanoseconds,
+    };
 }
 
 function getXPCData(conn, dict, buff, n) {
@@ -156,6 +174,8 @@ function extract(conn, xpc_object, dict) {
             return xpc_uint64_get_value(xpc_object);
         case "int64":
             return xpc_int64_get_value(xpc_object);
+        case "date":
+            return getXPCDate(xpc_object);
         case "array":
             ret = [];
             var count = xpc_array_get_count(xpc_object);


### PR DESCRIPTION
Hi!

This PR includes two changes:
- Added a `.gitignore` file.
- Added support for XPC Date.

For XPC Date, I chose to return an object with two properties: the datetime in ISO standard format and the nanoseconds. This approach allows you to easily deserialize it in Go and format it as needed (e.g., adding the offset to display the correct local time).

P.S. Ignore the previous PR. It seems that GitHub delete (& recreate) the branch when I changed its name and then it closes automatically the PR.
